### PR TITLE
Update Nightly-CI from ubuntu-20.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: 'Linux-GCC-Matlab-${{ matrix.matlab_version }}' 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         matlab_version: [R2020b, R2021a, R2021b, R2022a]


### PR DESCRIPTION
The `ubuntu-20.04` image is being removed, see https://github.com/actions/runner-images/issues/11101 .